### PR TITLE
Revert header to older version while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,6 @@
 <body>
     <div class="container">
         <header>
-            <div class="header-content">
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
                 <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -68,33 +68,12 @@ body {
 header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
-.header-content {
-    display: flex;
-    flex-direction: column;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -797,18 +776,7 @@ details[open] .suggested-header::before {
     
     header {
         padding: 1rem;
-        flex-direction: column;
-        gap: 1rem;
-        align-items: flex-start;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
-    .theme-toggle {
-        align-self: flex-end;
-        margin-top: -2.5rem;
+        justify-content: flex-end;
     }
     
     .chat-messages {


### PR DESCRIPTION
Fixes #2

This PR reverts the header to an older version while preserving the theme toggle functionality:

- Removes "Course Materials Assistant" header title
- Removes subtitle about "Ask questions about courses, instructors, and content"
- Removes horizontal border line under header
- Keeps theme toggle button functionality intact
- Cleans up unused CSS styles for removed elements
- Updates responsive design CSS accordingly

Generated with [Claude Code](https://claude.ai/code)